### PR TITLE
Renamed to Missing Darwin Core Fields

### DIFF
--- a/R/mod_missing_data.R
+++ b/R/mod_missing_data.R
@@ -65,7 +65,7 @@ mod_missing_data_ui <- function(id){
     ),
     tags$br(),
     tags$br(),
-    h4("List of Important Columns Not Present in Dataset"),
+    h4("Missing Darwin Core Fields"),
     fluidRow(
       tabsetPanel(
         id = ns("second_tabset"),


### PR DESCRIPTION
Fix for [Issue #5 ](https://github.com/rahulchauhan049/dashboard.experiment/issues/5)