### PR TITLE
Task: To rename the App name from dashboard.experiment to bddashboard

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: dashboard.experiment
+Package: bddashboard
 Title: PKG_TITLE
 Version: 0.1.1
 Authors@R: person('Rahul', 'Chauhan', email = 'rahul.chauhan049@gmail.com', role = c('cre', 'aut'))

--- a/R/app_config.R
+++ b/R/app_config.R
@@ -5,7 +5,7 @@
 #' 
 #' @noRd
 app_sys <- function(...){
-  system.file(..., package = "dashboard.experiment")
+  system.file(..., package = "bddashboard")
 }
 
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -108,7 +108,7 @@ golem_add_external_resources <- function(){
     favicon(),
     bundle_resources(
       path = app_sys('app/www'),
-      app_title = 'dashboard.experiment'
+      app_title = 'bddashboard'
     ),
     tags$link(rel = "stylesheet", type = "text/css", href = "www/custom.css")
     # Add here other external resources

--- a/R/mod_DT.R
+++ b/R/mod_DT.R
@@ -38,7 +38,7 @@ mod_DT_server <- function(input, output, session, data_reactive, pre_selected){
   ns <- session$ns
   
   # dictionary <- read.csv("data/dictionary.csv")
-  group <- reactive(create_group(dashboard.experiment::dictionary, data_reactive$data))
+  group <- reactive(create_group(bddashboard::dictionary, data_reactive$data))
   
   missing <- vector()
   x <- vector()

--- a/R/mod_leaflet.R
+++ b/R/mod_leaflet.R
@@ -41,7 +41,7 @@ mod_leaflet_ui <- function(id){
 mod_leaflet_server <- function(input, output, session, data_reactive, data_original, pre_selected="kingdom"){
   ns <- session$ns
   
-  group <- reactive(create_group(dashboard.experiment::dictionary, data_reactive$data))
+  group <- reactive(create_group(bddashboard::dictionary, data_reactive$data))
   temp <- list()
   layer <- reactiveValues(temp=NULL, final=pre_selected)
   map <- reactiveValues(mapTextureTemp="Stamen.Watercolor", mapTextureFinal="Stamen.Watercolor")

--- a/R/mod_plot_field_selector.R
+++ b/R/mod_plot_field_selector.R
@@ -35,7 +35,7 @@ mod_plot_field_selector_server <- function(input, output, session,  data_reactiv
   ns <- session$ns
   
   
-  group <- reactive(create_group(dashboard.experiment::dictionary, data_reactive$data))
+  group <- reactive(create_group(bddashboard::dictionary, data_reactive$data))
   fields <- reactive(find_field_for_plot(data_reactive$data, plot_type, group()))
   
   

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# dashboard.experiment
+# bddashboard
 
 <!-- badges: start -->
 
@@ -21,25 +21,25 @@ This project is made completely during Google Summer of Code Program.
 
 ## Installation
 
-You can install the development version of dashboard.experiment from
-[GitHub](https://github.com/rahulchauhan049/dashboard.experiment) with:
+You can install the development version of bddashboard from
+[GitHub](https://github.com/bd-R/bddashboard) with:
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("rahulchauhan049/dashboard.experiment")
+devtools::install_github("bd-R/bddashboard")
 ```
 
 ``` r
-library("dashboard.experiment")
+library("bddashboard")
 ```
 
-## Using dashboard.experiment
+## Using bddashboard
 
-Follow these steps to run dashboard.experiment
+Follow these steps to run bddashboard
 
 ``` r
-dashboard.experiment::run_app()
-## Run the code to open dashboard.experiment
+bddashboard::run_app()
+## Run the code to open bddashboard
 ```
 
 ## Modules Overview
@@ -150,9 +150,9 @@ Navigation modules also plays a very big role in improving performance. No matte
 
 Well thats all about the module. Altough bddashboard is made to visualize biodiversity data, these modules will allow user to create their own dashboard. Without worrying about complexity of coding.
 
-dashboard.experiment is tries to show world how easy it become now to create a dashboard.
+bddashboard is tries to show world how easy it become now to create a dashboard.
 
-## dashboard.experiment Overview
+## bddashboard Overview
 
 
 ### Data Input Tab
@@ -207,6 +207,6 @@ This tab is to visualize time related data.
 
 We have tested this dashboard and all the modules with 1M data records. But bugs are part of programming. If you face any issue, please notify me.
 
-Please submit your feedback using this **[link](https://github.com/rahulchauhan049/dashboard.experiment/issues/new)**
+Please submit your feedback using this **[link](https://github.com/bd-R/bddashboard/issues/new)**
 
    :deciduous_tree: :mushroom: :shell: :fish: :frog: :honeybee: :turtle: :rooster: :whale2: :monkey: :octocat: 

--- a/app.R
+++ b/app.R
@@ -4,4 +4,4 @@
 
 pkgload::load_all(export_all = FALSE,helpers = FALSE,attach_testthat = FALSE)
 options( "golem.app.prod" = TRUE)
-dashboard.experiment::run_app() # add parameters here (if any)
+bddashboard::run_app() # add parameters here (if any)

--- a/dev/01_start.R
+++ b/dev/01_start.R
@@ -14,7 +14,7 @@
 ## Fill the DESCRIPTION ----
 ## Add meta data about your application
 golem::fill_desc(
-  pkg_name = "dashboard.experiment", # The Name of the package containing the App 
+  pkg_name = "bddashboard", # The Name of the package containing the App 
   pkg_title = "PKG_TITLE", # The Title of the package containing the App 
   pkg_description = "This package is to test the scalability of dashboard with large datasets", # The Description of the package containing the App 
   author_first_name = "Rahul", # Your First Name

--- a/dev/02_dev.R
+++ b/dev/02_dev.R
@@ -92,7 +92,7 @@ usethis::use_test( "app" )
 # Documentation
 
 ## Vignette ----
-usethis::use_vignette("dashboard.experiment")
+usethis::use_vignette("bddashboard")
 devtools::build_vignettes()
 
 ## Code coverage ----

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,5 +1,5 @@
 default:
-  golem_name: dashboard.experiment
+  golem_name: bddashboard
   golem_version: 0.0.0.9000
   app_prod: no
 production:


### PR DESCRIPTION
**Problem**
To rename the App name from dashboard.experiment to bddashboard

**Solution**
Users can now install the app and it will install with the name ```bddashboard```.
If the user wants to run the app, it'll be through ```bddashboard::run_app()```

![Screenshot 2021-07-28 at 7 54 34 PM](https://user-images.githubusercontent.com/31892209/127339990-15a4b337-82c9-4403-bb24-54fbfbfa7793.png)

![Screenshot 2021-07-28 at 7 57 35 PM](https://user-images.githubusercontent.com/31892209/127340075-940d95bd-82b3-4b3d-bdac-158b99e5e554.png)

